### PR TITLE
Adding Github action workflow for PR builds

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,50 @@
+name: "PR Build"
+
+on:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Check if submodule has been pulled
+        run: |
+          cd opamp-spec/
+          ls
+      - name: Build Jar with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: jar
+
+      - name: Publish Jar with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: publish
+
+      - name: Find the path of built jar
+        id: jar_path
+        run: echo "JAR_PATH=$(ls build/repos/snapshots/io/opentelemetry/opamp-java/1.0.0-SNAPSHOT/*.jar | grep "1.jar")" >> $GITHUB_OUTPUT
+
+      - name: Extract the jar to see the contents
+        run: |
+          jar -xvf "${{ steps.jar_path.outputs.JAR_PATH }}"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,10 +27,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-      - name: Check if submodule has been pulled
-        run: |
-          cd opamp-spec/
-          ls
       - name: Build Jar with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,11 +40,3 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: publish
-
-      - name: Find the path of built jar
-        id: jar_path
-        run: echo "JAR_PATH=$(ls build/repos/snapshots/io/opentelemetry/opamp-java/1.0.0-SNAPSHOT/*.jar | grep "1.jar")" >> $GITHUB_OUTPUT
-
-      - name: Extract the jar to see the contents
-        run: |
-          jar -xvf "${{ steps.jar_path.outputs.JAR_PATH }}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,27 @@
 plugins {
   id("otel.java-conventions")
+  id("java-library")
+  id("otel.publish-conventions")
 }
+
+apply(from = "version.gradle.kts")
 
 repositories {
   mavenCentral()
   mavenLocal()
+}
+
+dependencies {
+  implementation(project(":proto"))
+}
+
+group = "io.opentelemetry"
+
+tasks.jar {
+  from(sourceSets.main.get().output)
+  dependsOn(configurations.runtimeClasspath)
+  from({
+    configurations.runtimeClasspath.get().filter { it.name.equals("proto-$version.jar") }.map { zipTree(it) }
+  })
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    `maven-publish`
+    signing
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("maven") {
+            afterEvaluate {
+                artifactId = base.archivesName.get()
+                pom.description.set(project.description)
+            }
+
+            from(components["java"])
+
+            pom {
+                name.set("OpAMP Protocol")
+                url.set("https://github.com/open-telemetry/opamp-java")
+
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("opentelemetry")
+                        name.set("OpenTelemetry")
+                        url.set("https://github.com/open-telemetry/community")
+                    }
+                }
+
+                scm {
+                    connection.set("scm:git:git@github.com:open-telemetry/opamp-java.git")
+                    developerConnection.set("scm:git:git@github.com:open-telemetry/opamp-java.git")
+                    url.set("git@github.com:open-telemetry/opamp-java.git")
+                }
+            }
+        }
+
+    }
+    repositories {
+        maven {
+            val snapshotsRepoUrl = layout.buildDirectory.dir("repos/snapshots")
+            url = uri(snapshotsRepoUrl)
+        }
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,0 +1,13 @@
+val snapshot = true  //set it to false when it is a release workflow
+
+allprojects {
+  var ver = "1.0.0"
+  val release = findProperty("otel.release")
+  if (release != null) {
+    ver += "-" + release
+  }
+  if (snapshot) {
+    ver += "-SNAPSHOT"
+  }
+  version = ver
+}


### PR DESCRIPTION
This is in continuation of https://github.com/open-telemetry/opamp-java/pull/5. The workflow triggers when a pull request is raised.

This checks out the proto submodules, builds the proto repo & includes all the proto classes in the final jar of opamp-java-library.

After building the library, it is published to a maven local repository. For publishing to a remote maven repo, I suggest we do it in a separate PR, once we finalise where we need to publish.

vmandal@vmandal-mac opamp-java % tree build/repos/snapshots/io/opentelemetry/opamp-java/1.0.0-SNAPSHOT/
build/repos/snapshots/io/opentelemetry/opamp-java/1.0.0-SNAPSHOT/
├── maven-metadata.xml
├── maven-metadata.xml.md5
├── maven-metadata.xml.sha1
├── maven-metadata.xml.sha256
├── maven-metadata.xml.sha512
├── opamp-java-1.0.0-20221212.134009-1-javadoc.jar
├── opamp-java-1.0.0-20221212.134009-1-javadoc.jar.md5
├── opamp-java-1.0.0-20221212.134009-1-javadoc.jar.sha1
├── opamp-java-1.0.0-20221212.134009-1-javadoc.jar.sha256
├── opamp-java-1.0.0-20221212.134009-1-javadoc.jar.sha512
├── opamp-java-1.0.0-20221212.134009-1-sources.jar
├── opamp-java-1.0.0-20221212.134009-1-sources.jar.md5
├── opamp-java-1.0.0-20221212.134009-1-sources.jar.sha1
├── opamp-java-1.0.0-20221212.134009-1-sources.jar.sha256
├── opamp-java-1.0.0-20221212.134009-1-sources.jar.sha512
├── opamp-java-1.0.0-20221212.134009-1.jar
├── opamp-java-1.0.0-20221212.134009-1.jar.md5
├── opamp-java-1.0.0-20221212.134009-1.jar.sha1
├── opamp-java-1.0.0-20221212.134009-1.jar.sha256
├── opamp-java-1.0.0-20221212.134009-1.jar.sha512
├── opamp-java-1.0.0-20221212.134009-1.module
├── opamp-java-1.0.0-20221212.134009-1.module.md5
├── opamp-java-1.0.0-20221212.134009-1.module.sha1
├── opamp-java-1.0.0-20221212.134009-1.module.sha256
├── opamp-java-1.0.0-20221212.134009-1.module.sha512
├── opamp-java-1.0.0-20221212.134009-1.pom
├── opamp-java-1.0.0-20221212.134009-1.pom.md5
├── opamp-java-1.0.0-20221212.134009-1.pom.sha1
├── opamp-java-1.0.0-20221212.134009-1.pom.sha256
└── opamp-java-1.0.0-20221212.134009-1.pom.sha512
